### PR TITLE
updating AccoundID from number to string to fix leading 0 error

### DIFF
--- a/bg-role/breakglassrole.tf
+++ b/bg-role/breakglassrole.tf
@@ -1,5 +1,5 @@
 variable "AccoundID" {
-  type        = number
+  type        = string
   description = "Enter the AWS account ID where the BreakGlassUser is deployed"
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Type for AccoundID in bg-role tf file was previously a **number**, which didn't account for account numbers with leading zeroes and caused errors when deploying. This minor change modifies AccoundID type to **string**. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
