### PR TITLE
update Account ID type and validation

### DIFF
--- a/bg-role/breakglassrole.tf
+++ b/bg-role/breakglassrole.tf
@@ -1,6 +1,11 @@
 variable "AccoundID" {
-  type        = number
+  type        = string
   description = "Enter the AWS account ID where the BreakGlassUser is deployed"
+
+  validation {
+    condition     = length(var.AccoundID) == 12 && can(regex("^[[digits]]+$", var.AccoundID))
+    error_message = "Account ID must be 12 digits"
+  }
 }
 
 resource "aws_iam_role" "BreakGlassRole" {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* AccoundID variable was previously type **number**. This led to Account IDs with leading zeroes breaking the template. This PR updates the type to **string** and adds validation to ensure the value entered is 12 digits. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
