### PR TITLE
Bg role update account

### DIFF
--- a/bg-role/breakglassrole.tf
+++ b/bg-role/breakglassrole.tf
@@ -3,7 +3,7 @@ variable "AccoundID" {
   description = "Enter the AWS account ID where the BreakGlassUser is deployed"
 
   validation {
-    condition     = length(var.AccoundID) == 12 && can(regex("^[[digits]]+$", var.AccoundID))
+    condition     = length(var.AccoundID) == 12 && can(regex("^[[:digit:]]+$", var.AccoundID))
     error_message = "Account ID must be 12 digits"
   }
 }

--- a/bg-role/breakglassrole.tf
+++ b/bg-role/breakglassrole.tf
@@ -1,6 +1,11 @@
 variable "AccoundID" {
-  type        = number
+  type        = string
   description = "Enter the AWS account ID where the BreakGlassUser is deployed"
+
+  validation {
+    condition     = length(var.AccoundID) == 12 && can(regex("^[[digits]]+$", var.AccoundID))
+    error_message = "Account ID must be 12 digits"
+  }
 }
 
 resource "aws_iam_role" "BreakGlassRole" {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* AccoundID was originally of type **number**, which led to the template breaking when received account ids with leading zeroes. This PR updates the type to **string** and adds validation to ensure input is 12 digits. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
